### PR TITLE
server_name problem

### DIFF
--- a/src/EvaThumber/Url.php
+++ b/src/EvaThumber/Url.php
@@ -460,10 +460,14 @@ class Url
         }
         $pageURL .= '://';
 
-        if (isset($_SERVER['SERVER_PORT']) && $_SERVER['SERVER_PORT'] != '80') {
-            $pageURL .= $serverName . ':' . $_SERVER['SERVER_PORT'] . $requestUri;
+        if (isset($_SERVER['HTTP_HOST'])) {
+            $pageURL .= $_SERVER['HTTP_HOST'] . $requestUri;
         } else {
-            $pageURL .= $serverName . $requestUri;
+            if (isset($_SERVER['SERVER_PORT']) && $_SERVER['SERVER_PORT'] != '80') {
+                $pageURL .= $serverName . ':' . $_SERVER['SERVER_PORT'] . $requestUri;
+            } else {
+                $pageURL .= $serverName . $requestUri;
+            }
         }
         return $pageURL;
     }


### PR DESCRIPTION
server_name  "~^(?<name>\w\d{1,3}+).example.net$";
the function getCurrentUrl() will return the regex string as host, and parse_url() will return false.
